### PR TITLE
Remove import prefixes. Update API setup commands and some typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ To run this proxy locally on your own machine, follow these steps:
 4. Set your Groq API token key as an environment variable:
 ```export GROQ_API_KEY=your-api-key```
 
-5. Run the FastAPI server:
+5. Create uvicorn logs folder:
+```mkdir .logs```
+
+6. Run the FastAPI server:
 ```uvicorn main:app --reload```
 
 
@@ -49,7 +52,7 @@ To use the pre-built server, simply make requests to the following base URL:
 This README is organized into three main sections, each showcasing different aspects of FunckyCall.ai:
 
 - **Sending POST Requests**: Here, I explore the functionality of sending direct POST requests to LLMs using FunckyCall.ai. This section highlights the flexibility and control offered by the library when interacting with LLMs.
-- **FunckyHub**: The third section introduces the concept of FunckyHub, a usefull feature that simplifies the process of executing functions. With FunckyHub, there is no need to send the function JSON schema explicitly, as the functions are already hosted on the proxy server. This approach streamlines the workflow, allowing developers to obtain results with a single call without having to handle function call is production server.
+- **FunckyHub**: The second section introduces the concept of FunckyHub, a useful feature that simplifies the process of executing functions. With FunckyHub, there is no need to send the function JSON schema explicitly, as the functions are already hosted on the proxy server. This approach streamlines the workflow, allowing developers to obtain results with a single call without having to handle function call is production server.
 - **Using FunckyCall with PhiData**: In this section, I demonstrate how FunckyCall.ai can be seamlessly integrated with other libraries such as my favorite one, the PhiData library, leveraging its built-in tools to connect to LLMs and perform external tool requests.
 
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To run this proxy locally on your own machine, follow these steps:
 ```mkdir .logs```
 
 6. Run the FastAPI server:
-```uvicorn main:app --reload```
+```uvicorn --app-dir app/ main:app --reload```
 
 
 ## Using the Pre-built Server 🌐

--- a/app/libs/chains.py
+++ b/app/libs/chains.py
@@ -5,9 +5,9 @@ import json
 import uuid
 from fastapi import Request
 from fastapi.responses import JSONResponse
-from app.providers import BaseProvider
-from app.prompts import SYSTEM_MESSAGE, SUFFIX, get_func_result_guide
-from app.providers import GroqProvider
+from providers import BaseProvider
+from prompts import SYSTEM_MESSAGE, SUFFIX, get_func_result_guide
+from providers import GroqProvider
 import importlib
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -3,11 +3,11 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from starlette.requests import Request
-from app.routes import proxy
-from app.routes import examples
+from routes import proxy
+from routes import examples
 
 
-from app.utils import create_logger
+from utils import create_logger
 import os
 from dotenv import load_dotenv
 load_dotenv()

--- a/app/routes/proxy.py
+++ b/app/routes/proxy.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Response, Request, Path, Query
 from fastapi.responses import JSONResponse
-from app.libs.chains import (
+from libs.chains import (
     Context,
     ProviderSelectionHandler,
     ToolExtractionHandler,


### PR DESCRIPTION
Hi, very excited to see this project come out, was eager to test this proxy!

I was unable to get the proxy running without some modifications.
This behavior was replicated in mine and a co-worker computer.

After removing the `app.` prefix from the imports and creating a `.logs` folder, it worked as intended.
I also needed to specify the `app-dir` for uvicorn or go down another folder level, so I updated the uvicorn command and a few typos I found.

It's my first PR, so please let me know if it's ok :)